### PR TITLE
Set additional header

### DIFF
--- a/package-brave/background.js
+++ b/package-brave/background.js
@@ -1,8 +1,11 @@
 chrome.webRequest.onBeforeSendHeaders.addListener(data => {
 	for (let header of data.requestHeaders) {
-		if (header.name.toLowerCase() === 'user-agent') {
-			header.value = navigator.userAgent.split('Gecko')[0] + 'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0';
-		}
+		let currentHeader = header.name.toLowerCase();
+	        if (currentHeader === 'user-agent') {
+	            header.value = navigator.userAgent.split('Gecko')[0] + 'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0';
+	        } else if (currentHeader === 'sec-ch-ua') {
+	            header.value = '\"Not_A Brand\";v=\"8\", \"Chromium\";v=\"120\", \"Microsoft Edge\";v=\"120\"';
+	        }
 	}
 	return { requestHeaders: data.requestHeaders };
 }, { urls: ['https://*.bing.com/*'] }, ['blocking', 'requestHeaders']);

--- a/package-brave/background.js
+++ b/package-brave/background.js
@@ -2,7 +2,7 @@ chrome.webRequest.onBeforeSendHeaders.addListener(data => {
 	for (let header of data.requestHeaders) {
 		let currentHeader = header.name.toLowerCase();
 	        if (currentHeader === 'user-agent') {
-	            header.value = navigator.userAgent.split('Gecko')[0] + 'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0';
+	            header.value = navigator.userAgent.split('AppleWebKit')[0] + 'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0';
 	        } else if (currentHeader === 'sec-ch-ua') {
 	            header.value = '\"Not_A Brand\";v=\"8\", \"Chromium\";v=\"120\", \"Microsoft Edge\";v=\"120\"';
 	        }

--- a/package/background.js
+++ b/package/background.js
@@ -11,6 +11,16 @@ chrome.declarativeNetRequest.updateDynamicRules({
                         operation: 'set',
                         header: 'user-agent',
                         value: navigator.userAgent.split('AppleWebKit')[0] + 'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0'
+                    },
+                    {
+                        operation: 'set',
+                        header: 'sec-ch-ua',
+                        value: '\"Not_A Brand\";v=\"8\", \"Chromium\";v=\"120\", \"Microsoft Edge\";v=\"120\"'
+                    },
+                    {
+                        operation: 'set',
+                        header: 'sec-ch-ua-full-version-list',
+                        value: '\"Not_A Brand\";v=\"8.0.0.0\", \"Chromium\";v=\"120.0.6099.234\", \"Microsoft Edge\";v=\"120.0.2210.144\"'
                     }
                 ]
             },


### PR DESCRIPTION
Currently, when 'set-ch-ua' is present in a request, bing considers it a higher priority than 'user-agent'. This also works if you "remove" this header rather than "set" it. The 'sec-ch-ua-full-version-list' is not necessarily be set/remove, it is present in requests, but is ignored for now.

Brave, surprisingly, works with the original 'sec-ch-ua' as well, but I think it's not unreasonable to set it too; The 'sec-ch-ua-full-version-list' is missing from his requests.